### PR TITLE
Leif/api

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -1,18 +1,23 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
 name: macOS
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["**"]
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: swift build -v
-    - name: Run tests
-      run: swift test -v
+      - uses: swift-actions/setup-swift@v1
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - uses: actions/checkout@v3
+      - name: Build for release
+        run: swift build -v -c release
+      - name: Test
+        run: swift test -v

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "Network",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v11),
-        .watchOS(.v7),
-        .tvOS(.v14)
+        .iOS(.v16),
+        .macOS(.v13),
+        .watchOS(.v9),
+        .tvOS(.v16)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -22,7 +22,8 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "Network"),
+            name: "Network"
+        ),
         .testTarget(
             name: "NetworkTests",
             dependencies: ["Network"]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,66 @@ do {
 
 ```
 
+### Defining an API
+
+In order to define an API, you must first create an `Endpoint`. This is a protocol that outlines the basic components of a network request. These components include the URL, HTTP request method, path, headers, and body of the request.
+
+Here's an example of an `Endpoint`:
+
+```swift
+enum ExampleEndpoint: Endpoint {
+    static var url: URL { URL(string: "example.com")! }
+
+    case hello
+
+    var method: HTTPRequestMethod {
+        switch self {
+        case .hello:    return .GET
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .hello:    return "hello"
+        }
+    }
+
+    var headers: [String: String] {
+        switch self {
+        case .hello:
+            return [
+                "id": "hello"
+            ]
+        }
+    }
+
+    var body: Data? {
+        switch self {
+        case .hello:    return "hello".data(using: .utf8)
+        }
+    }
+}
+
+```
+
+Once the `Endpoint` is defined, you can create an instance of `API` or `MockAPI` (for testing) to send requests to the endpoint. Here's how you can use the `MockAPI` in a test:
+
+```swift
+func testAPI() async throws {
+    let api = MockAPI<ExampleEndpoint>()
+    let expectedString = "hello"
+
+    let dataResponse = try await api.request(.hello)
+    let data = try XCTUnwrap(dataResponse.data)
+    let string = String(data: data, encoding: .utf8)
+
+    XCTAssertEqual(string, expectedString)
+}
+
+```
+
+The above test creates a `MockAPI`, sends a `GET` request to the `hello` endpoint, and checks if the response matches the expected string "hello".
+
 ## Contributing
 
 Contributions to `Network` are welcome! If you have ideas for improvements, find a bug, or want to contribute code, please submit a pull request. For major changes, please open an issue first to discuss potential updates.

--- a/Sources/Network/API.swift
+++ b/Sources/Network/API.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+open class API<APIEndpoint: Endpoint> {
+    var network: Networking
+
+    public init() {
+        network = Network()
+    }
+
+    open func request(_ endpoint: APIEndpoint) async throws -> DataResponse {
+        try await network.request(
+            for: APIEndpoint.url.appending(path: endpoint.path),
+            method: endpoint.method,
+            headerFields: endpoint.headers,
+            body: endpoint.body
+        )
+    }
+}

--- a/Sources/Network/API.swift
+++ b/Sources/Network/API.swift
@@ -1,12 +1,20 @@
 import Foundation
 
+/// An open class that defines the base API. It will request data from a network pointing to a specific API endpoint.
 open class API<APIEndpoint: Endpoint> {
-    var network: Networking
+    private let network: Networking
 
+    /// Initializes a new instance of the API class.
     public init() {
         network = Network()
     }
 
+    /**
+     Sends an asynchronous network request to a specific API endpoint.
+     - Parameter endpoint: The API endpoint to which the request will be sent.
+     - Throws: If there is an error during the network request.
+     - Returns: The data response from the network request.
+     */
     open func request(_ endpoint: APIEndpoint) async throws -> DataResponse {
         try await network.request(
             for: APIEndpoint.url.appending(path: endpoint.path),

--- a/Sources/Network/DataResponse.swift
+++ b/Sources/Network/DataResponse.swift
@@ -21,7 +21,6 @@ public struct DataResponse {
     /// - Parameters:
     ///   - tuple: A tuple containing data as the first element and URL response as the second element.
     public init(_ tuple: (Data?, URLResponse?)) {
-        self.data = tuple.0
-        self.response = tuple.1
+        self.init(data: tuple.0, response: tuple.1)
     }
 }

--- a/Sources/Network/Endpoint.swift
+++ b/Sources/Network/Endpoint.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public protocol Endpoint: Hashable {
+    static var url: URL { get }
+
+    var method: HTTPRequestMethod { get }
+    var path: String { get }
+    var headers: [String: String] { get }
+    var body: Data? { get }
+}

--- a/Sources/Network/Endpoint.swift
+++ b/Sources/Network/Endpoint.swift
@@ -1,10 +1,31 @@
 import Foundation
 
+/**
+ This protocol defines the basic structure of an endpoint in a HTTP network request.
+
+ - Note:
+    This protocol requires any conforming type to provide the necessary properties for constructing a HTTP request.
+
+ - Properties:
+    - `url`: The base URL for the endpoint.
+    - `method`: The HTTP request method (GET, POST, etc.)
+    - `path`: The path component of the URL.
+    - `headers`: The HTTP headers to include in the request.
+    - `body`: The body of the HTTP request, if any.
+ */
 public protocol Endpoint: Hashable {
+    /// The base URL for the endpoint.
     static var url: URL { get }
 
+    /// The HTTP request method (GET, POST, etc.)
     var method: HTTPRequestMethod { get }
+
+    /// The path component of the URL.
     var path: String { get }
+
+    /// The HTTP headers to include in the request.
     var headers: [String: String] { get }
+
+    /// The body of the HTTP request, if any.
     var body: Data? { get }
 }

--- a/Sources/Network/MockAPI.swift
+++ b/Sources/Network/MockAPI.swift
@@ -1,4 +1,32 @@
+/**
+ An open class that inherits from the base API class. It overrides the request method
+ to use a mock network for testing purposes.
+
+ - Parameter APIEndpoint: The endpoint where the API will point.
+ - Returns: A mocked data response for testing.
+
+ Usage:
+
+ ```swift
+ let mockAPI = MockAPI<MyEndpoint>()
+ let response = try await mockAPI.request(.someEndpoint)
+
+ ```
+
+ This will return a mock response using the data provided in the mockEndpoint body.
+ */
 open class MockAPI<APIEndpoint: Endpoint>: API<APIEndpoint> {
+    /**
+
+    Sends an asynchronous network request to a specific API endpoint using a mock network.
+
+    - Parameter endpoint: The API endpoint to which the request will be sent.
+
+    - Throws: If there is an error during the network request.
+
+    - Returns: A mocked data response for testing. The data will just be the body of the request and there will be no response.
+
+    */
     open override func request(_ endpoint: APIEndpoint) async throws -> DataResponse {
         try await MockNetwork(
             responseData: endpoint.body,

--- a/Sources/Network/MockAPI.swift
+++ b/Sources/Network/MockAPI.swift
@@ -1,0 +1,14 @@
+open class MockAPI<APIEndpoint: Endpoint>: API<APIEndpoint> {
+    open override func request(_ endpoint: APIEndpoint) async throws -> DataResponse {
+        try await MockNetwork(
+            responseData: endpoint.body,
+            response: nil
+        )
+        .request(
+            for: APIEndpoint.url.appending(path: endpoint.path),
+            method: endpoint.method,
+            headerFields: endpoint.headers,
+            body: endpoint.body
+        )
+    }
+}

--- a/Sources/Network/MockNetwork.swift
+++ b/Sources/Network/MockNetwork.swift
@@ -13,6 +13,13 @@ open class MockNetwork: Network {
         self.response = response
     }
 
+    /// Sends an Mock HTTP request.
+    /// - Parameters:
+    ///   - url: The URL to which the request will be sent.
+    ///   - method: The HTTP method to be used.
+    ///   - headerFields: Header fields to include in the request.
+    ///   - body: Optional body to be including with the request.
+    /// - Returns: A `DataResponse` object containing the response data and URL response.
     public override func request(
         for url: URL,
         method: HTTPRequestMethod,

--- a/Sources/Network/MockNetwork.swift
+++ b/Sources/Network/MockNetwork.swift
@@ -1,73 +1,27 @@
 import Foundation
 
 /// A class that implements the `Networking` protocol to provide mock network responses.
-open class MockNetwork: Networking {
-    public init() { }
+open class MockNetwork: Network {
+    private let responseData: Data?
+    private let response: URLResponse?
 
-    open func get(
-        url: URL,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
+    public init(
+        responseData: Data?,
+        response: URLResponse?
+    ) {
+        self.responseData = responseData
+        self.response = response
     }
 
-    open func head(
-        url: URL,
-        headerFields: [String: String] = [:]
+    public override func request(
+        for url: URL,
+        method: HTTPRequestMethod,
+        headerFields: [String: String],
+        body: Data?
     ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func connect(
-        url: URL,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func options(
-        url: URL,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func trace(
-        url: URL,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func post(
-        url: URL,
-        body: Data?,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func put(
-        url: URL,
-        body: Data?,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func patch(
-        url: URL,
-        body: Data?,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
-    }
-
-    open func delete(
-        url: URL,
-        body: Data?,
-        headerFields: [String: String] = [:]
-    ) async throws -> DataResponse {
-        DataResponse(data: nil, response: URLResponse())
+        DataResponse(
+            data: responseData,
+            response: response
+        )
     }
 }

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -4,6 +4,23 @@ import Foundation
 open class Network: Networking {
     public init() { }
 
+    open func request(
+        for url: URL,
+        method : HTTPRequestMethod,
+        headerFields: [String: String],
+        body: Data?
+    ) async throws -> DataResponse {
+        var request = URLRequest(url: url)
+
+        request.httpMethod = method.rawValue
+        request.allHTTPHeaderFields = headerFields
+        request.httpBody = body
+
+        return DataResponse(
+            try await URLSession.shared.data(for: request)
+        )
+    }
+
     open func `get`(
         url: URL,
         headerFields: [String: String] = [
@@ -11,14 +28,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        DataResponse(
-            try await URLSession.shared.data(
-                for: request(
-                    for: url,
-                    method: .GET,
-                    headerFields: headerFields
-                )
-            )
+        try await request(
+            for: url,
+            method: .GET,
+            headerFields: headerFields,
+            body: nil
         )
     }
 
@@ -29,14 +43,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        DataResponse(
-            try await URLSession.shared.data(
-                for: request(
-                    for: url,
-                    method: .HEAD,
-                    headerFields: headerFields
-                )
-            )
+        try await request(
+            for: url,
+            method: .HEAD,
+            headerFields: headerFields,
+            body: nil
         )
     }
 
@@ -47,14 +58,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        DataResponse(
-            try await URLSession.shared.data(
-                for: request(
-                    for: url,
-                    method: .CONNECT,
-                    headerFields: headerFields
-                )
-            )
+        try await request(
+            for: url,
+            method: .CONNECT,
+            headerFields: headerFields,
+            body: nil
         )
     }
 
@@ -65,14 +73,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        DataResponse(
-            try await URLSession.shared.data(
-                for: request(
-                    for: url,
-                    method: .OPTIONS,
-                    headerFields: headerFields
-                )
-            )
+        try await request(
+            for: url,
+            method: .OPTIONS,
+            headerFields: headerFields,
+            body: nil
         )
     }
 
@@ -83,14 +88,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        DataResponse(
-            try await URLSession.shared.data(
-                for: request(
-                    for: url,
-                    method: .TRACE,
-                    headerFields: headerFields
-                )
-            )
+        try await request(
+            for: url,
+            method: .TRACE,
+            headerFields: headerFields,
+            body: nil
         )
     }
 
@@ -102,18 +104,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        var request = request(
+        try await request(
             for: url,
             method: .POST,
-            headerFields: headerFields
-        )
-
-        request.httpBody = body
-
-        return DataResponse(
-            try await URLSession.shared.data(
-                for: request
-            )
+            headerFields: headerFields,
+            body: body
         )
     }
 
@@ -125,18 +120,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        var request = request(
+        try await request(
             for: url,
             method: .PUT,
-            headerFields: headerFields
-        )
-
-        request.httpBody = body
-
-        return DataResponse(
-            try await URLSession.shared.data(
-                for: request
-            )
+            headerFields: headerFields,
+            body: body
         )
     }
 
@@ -148,18 +136,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        var request = request(
+        try await request(
             for: url,
             method: .PATCH,
-            headerFields: headerFields
-        )
-
-        request.httpBody = body
-
-        return DataResponse(
-            try await URLSession.shared.data(
-                for: request
-            )
+            headerFields: headerFields,
+            body: body
         )
     }
 
@@ -171,31 +152,11 @@ open class Network: Networking {
             "Accept": "application/json"
         ]
     ) async throws -> DataResponse {
-        var request = request(
+        try await request(
             for: url,
             method: .DELETE,
-            headerFields: headerFields
+            headerFields: headerFields,
+            body: body
         )
-
-        request.httpBody = body
-
-        return DataResponse(
-            try await URLSession.shared.data(
-                for: request
-            )
-        )
-    }
-
-    open func request(
-        for url: URL,
-        method : HTTPRequestMethod,
-        headerFields: [String: String]
-    ) -> URLRequest {
-        var request = URLRequest(url: url)
-
-        request.httpMethod = method.rawValue
-        request.allHTTPHeaderFields = headerFields
-
-        return request
     }
 }

--- a/Sources/Network/Networking.swift
+++ b/Sources/Network/Networking.swift
@@ -2,6 +2,20 @@ import Foundation
 
 /// A protocol defining networking methods for making HTTP requests.
 public protocol Networking {
+    /// Sends an HTTP  request to the specified URL.
+    /// - Parameters:
+    ///   - url: The URL to which the request will be sent.
+    ///   - method: The HTTP method to be used.
+    ///   - headerFields: Header fields to include in the request.
+    ///   - body: Optional body to be including with the request.
+    /// - Returns: A `DataResponse` object containing the response data and URL response.
+    func request(
+        for url: URL,
+        method : HTTPRequestMethod,
+        headerFields: [String: String],
+        body: Data?
+    ) async throws -> DataResponse
+
     /// Sends an HTTP GET request to the specified URL.
     /// - Parameters:
     ///   - url: The URL to which the request will be sent.

--- a/Sources/Network/Networking.swift
+++ b/Sources/Network/Networking.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A protocol defining networking methods for making HTTP requests.
 public protocol Networking {
-    /// Sends an HTTP  request to the specified URL.
+    /// Sends an HTTP request to the specified URL.
     /// - Parameters:
     ///   - url: The URL to which the request will be sent.
     ///   - method: The HTTP method to be used.

--- a/Tests/NetworkTests/MockNetworkTests.swift
+++ b/Tests/NetworkTests/MockNetworkTests.swift
@@ -2,90 +2,73 @@ import XCTest
 @testable import Network
 
 final class MockNetworkTests: XCTestCase {
-    class StringMockNetwork: MockNetwork {
-        func data(for method: HTTPRequestMethod) -> DataResponse {
-            DataResponse(data: "Hello, \(method.rawValue)".data(using: .utf8), response: URLResponse())
-        }
-
-        override func get(
-            url: URL,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .GET)
-        }
-
-        override func head(
-            url: URL,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .HEAD)
-        }
-
-        override func connect(
-            url: URL,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .CONNECT)
-        }
-
-        override func options(
-            url: URL,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .OPTIONS)
-        }
-
-        override func trace(
-            url: URL,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .TRACE)
-        }
-
-        override func post(
-            url: URL,
-            body: Data?,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .POST)
-        }
-
-        override func put(
-            url: URL,
-            body: Data?,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .PUT)
-        }
-
-        override func patch(
-            url: URL,
-            body: Data?,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .PATCH)
-        }
-
-        override func delete(
-            url: URL,
-            body: Data?,
-            headerFields: [String: String] = [:]
-        ) async throws -> DataResponse {
-            data(for: .DELETE)
-        }
-
-    }
-
-    let network: StringMockNetwork = StringMockNetwork()
-
     var url: URL {
         get throws {
             try XCTUnwrap(URL(string: Self.self.description()))
         }
     }
 
+    func testRequest() async throws {
+        let expectedString = "Hello, world!"
+        let network = MockNetwork(
+            responseData: expectedString.data(using: .utf8),
+            response: nil
+        )
+
+        let dataResponse = try await network.request(for: try url, method: .GET, headerFields: [:], body: nil)
+        let data = try XCTUnwrap(dataResponse.data)
+        let string = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(string, expectedString)
+    }
+
+    func testAPI() async throws {
+        enum ExampleEndpoint: Endpoint {
+            static var url: URL { URL(string: "example")! }
+
+            case hello
+
+            var method: HTTPRequestMethod {
+                switch self {
+                case .hello:    return .GET
+                }
+            }
+
+            var path: String {
+                switch self {
+                case .hello:    return "hello"
+                }
+            }
+
+            var headers: [String: String] {
+                switch self {
+                case .hello:
+                    return [
+                        "id": "hello"
+                    ]
+                }
+            }
+
+            var body: Data? {
+                switch self {
+                case .hello:    return "hello".data(using: .utf8)
+                }
+            }
+        }
+
+        let api = MockAPI<ExampleEndpoint>()
+        let expectedString = "hello"
+
+        let dataResponse = try await api.request(.hello)
+        let data = try XCTUnwrap(dataResponse.data)
+        let string = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(string, expectedString)
+    }
+
     func testGet() async throws {
         let expectedString = "Hello, GET"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.get(url: url)
         let data = try XCTUnwrap(dataResponse.data)
@@ -96,6 +79,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testHead() async throws {
         let expectedString = "Hello, HEAD"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.head(url: url)
         let data = try XCTUnwrap(dataResponse.data)
@@ -106,6 +90,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testPost() async throws {
         let expectedString = "Hello, POST"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.post(url: url, body: nil)
         let data = try XCTUnwrap(dataResponse.data)
@@ -116,6 +101,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testPut() async throws {
         let expectedString = "Hello, PUT"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.put(url: url, body: nil)
         let data = try XCTUnwrap(dataResponse.data)
@@ -126,6 +112,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testDelete() async throws {
         let expectedString = "Hello, DELETE"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.delete(url: url, body: nil)
         let data = try XCTUnwrap(dataResponse.data)
@@ -136,6 +123,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testConnect() async throws {
         let expectedString = "Hello, CONNECT"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.connect(url: url)
         let data = try XCTUnwrap(dataResponse.data)
@@ -146,6 +134,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testOptions() async throws {
         let expectedString = "Hello, OPTIONS"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.options(url: url)
         let data = try XCTUnwrap(dataResponse.data)
@@ -156,6 +145,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testTrace() async throws {
         let expectedString = "Hello, TRACE"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.trace(url: url)
         let data = try XCTUnwrap(dataResponse.data)
@@ -166,6 +156,7 @@ final class MockNetworkTests: XCTestCase {
 
     func testPatch() async throws {
         let expectedString = "Hello, PATCH"
+        let network = MockNetwork(responseData: expectedString.data(using: .utf8), response: nil)
 
         let dataResponse = try await network.patch(url: url, body: nil)
         let data = try XCTUnwrap(dataResponse.data)


### PR DESCRIPTION
### Defining an API

In order to define an API, you must first create an `Endpoint`. This is a protocol that outlines the basic components of a network request. These components include the URL, HTTP request method, path, headers, and body of the request.

Here's an example of an `Endpoint`:

```swift
enum ExampleEndpoint: Endpoint {
    static var url: URL { URL(string: "example.com")! }

    case hello

    var method: HTTPRequestMethod {
        switch self {
        case .hello:    return .GET
        }
    }

    var path: String {
        switch self {
        case .hello:    return "hello"
        }
    }

    var headers: [String: String] {
        switch self {
        case .hello:
            return [
                "id": "hello"
            ]
        }
    }

    var body: Data? {
        switch self {
        case .hello:    return "hello".data(using: .utf8)
        }
    }
}

```

Once the `Endpoint` is defined, you can create an instance of `API` or `MockAPI` (for testing) to send requests to the endpoint. Here's how you can use the `MockAPI` in a test:

```swift
func testAPI() async throws {
    let api = MockAPI<ExampleEndpoint>()
    let expectedString = "hello"

    let dataResponse = try await api.request(.hello)
    let data = try XCTUnwrap(dataResponse.data)
    let string = String(data: data, encoding: .utf8)

    XCTAssertEqual(string, expectedString)
}

```

The above test creates a `MockAPI`, sends a `GET` request to the `hello` endpoint, and checks if the response matches the expected string "hello".